### PR TITLE
Potential fix for code scanning alert no. 4: Insecure TLS configuration

### DIFF
--- a/cmd/bwh/snapshot.go
+++ b/cmd/bwh/snapshot.go
@@ -591,7 +591,7 @@ func downloadFile(ctx context.Context, downloadURL, filepath string, expectedSiz
 	
 	// For IP-based HTTPS URLs, use more permissive TLS settings
 	if skipTLSVerify {
-		tlsConfig.MinVersion = tls.VersionTLS10 // Support older TLS versions
+		tlsConfig.MinVersion = tls.VersionTLS12 // Only support secure TLS versions
 		tlsConfig.MaxVersion = tls.VersionTLS13 // Support newest TLS versions
 		tlsConfig.CipherSuites = nil           // Use default cipher suites
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/strahe/bwh/security/code-scanning/4](https://github.com/strahe/bwh/security/code-scanning/4)

To fix the problem, update the TLS configuration in the `downloadFile` function so that the minimum TLS version is set to `tls.VersionTLS12` instead of `tls.VersionTLS10`. This change should be made on line 594 of `cmd/bwh/snapshot.go`. No other changes are required, as the rest of the configuration is acceptable (max version is set to TLS 1.3, cipher suites are default). No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
