### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/strahe/bwh/security/code-scanning/2](https://github.com/strahe/bwh/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the jobs only need to check out code and do not perform any write operations, the minimal permission required is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (for each job). The best approach is to add it at the top level, just after the `name` and before `on`, so that all jobs inherit this setting. No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
